### PR TITLE
Graceful exit even for uneditable changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,9 +19,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Security` in case of vulnerabilities
 
+## [1.0.2] - 2024-10-20
+
+### Fixed
+
+- If only changes are in .github/workflows/*.yml , then the action still should gracefully exit 0.
+
 ## [1.0.1] - 2024-10-20
 
-### `Changed`
+### Changed
 
 - A warning appears in the GitHub Actions Annotations section if changes occur and therefore a new branch is created.
 - A proposed manual changed linked from the warning in the GitHub Actions Annotations section.
@@ -30,6 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - This GitHub Action automates Prettier formatting across your project, ensuring consistent code styling by creating a new branch for review when necessary. It simplifies integrating Prettier into your workflow, although updates to workflow YAML files in `.github/workflows/` must be done manually.
 
-[Unreleased]: https://github.com/WorkOfStan/prettier-fix/compare/v1.0.1...HEAD
+[Unreleased]: https://github.com/WorkOfStan/prettier-fix/compare/v1.0.2...HEAD
+[1.0.2]: https://github.com/WorkOfStan/prettier-fix/compare/v1.0.1...v1.0.2?w=1
 [1.0.1]: https://github.com/WorkOfStan/prettier-fix/compare/v1.0.0...v1.0.1?w=1
 [1.0.0]: https://github.com/WorkOfStan/prettier-fix/releases/tag/v1.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- If only changes are in .github/workflows/*.yml , then the action still should gracefully exit 0.
+- If only changes are in .github/workflows/\*.yml , then the action still should gracefully exit 0.
 
 ## [1.0.1] - 2024-10-20
 

--- a/action.yml
+++ b/action.yml
@@ -67,7 +67,14 @@ runs:
             echo "::warning title=Manual change required::Changes detected in $file. Manual intervention required to avoid conflicts with Super-Linter."
             git diff --staged "$file"
           fi
-        done    
+        done
+
+        # Re-check after uneditable files reset
+        if [ -z "$(git status --porcelain)" ]; then
+          echo "No editable changes detected by Prettier. Exiting gracefully."
+          exit 0
+          # The rest of the script must be within the same step to really stop the execution
+        fi
 
         # Set branch name and create branch
         TIMESTAMP=$(date +'%y%m%d%H%M%S')


### PR DESCRIPTION
### Fixed
- If only changes are in .github/workflows/\*.yml , then the action still should gracefully exit 0.