### PR TITLE
Revert changes in .github/workflows/ one by one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Reset changes in .github/workflows/\*.yml before checking other changes, so that the action still should gracefully exit 0.
+- Revert changes in .github/workflows/\*.yml before checking other changes, so when only non-editable files should be changed, no new branch is created and the action still gracefully exit 0.
 
 ## [1.0.2] - 2024-10-20
 

--- a/action.yml
+++ b/action.yml
@@ -66,7 +66,10 @@ runs:
           if git diff --staged "$file" | grep -q .; then
             echo "::warning title=Manual change required::Changes detected in $file. Manual intervention required to avoid conflicts with Super-Linter."
             git diff --staged "$file"
+            # Unstage the changes git restore --staged "$file" or:
             git reset "$file"
+            # Discard changes in the working directory, so that it doesn't trigger status --porcelain
+            git restore "$file"             
           fi
         done
 


### PR DESCRIPTION
### Fixed
- Revert changes in .github/workflows/\*.yml before checking other changes, so when only non-editable files should be changed, no new branch is created and the action still gracefully exit 0.