### PR TITLE
Option to commit to the current branch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,5 +8,5 @@ updates:
     # Location of package manifests
     directory: "/"
     schedule:
-      # Check for updates to GitHub Actions every weekday
+      # Check for updates to GitHub Actions every week
       interval: "weekly"

--- a/.github/workflows/prettier-fix.yml
+++ b/.github/workflows/prettier-fix.yml
@@ -7,8 +7,8 @@ permissions:
 
 jobs:
   prettier-fix:
-    # Run only if the actor is not the GitHub Actions bot
-    if: github.actor != 'github-actions[bot]'
+    ## Run only if the actor is not the GitHub Actions bot
+    #if: github.actor != 'github-actions[bot]'
     runs-on: ubuntu-latest
     # Limit the running time
     timeout-minutes: 10
@@ -16,5 +16,6 @@ jobs:
       - name: Invoke the Prettier fix
         # Use the latest commit in the main branch.
         uses: WorkOfStan/prettier-fix@main
-        #with:
+        with:
         #  node-version: "20"
+          commit-changes: true

--- a/.github/workflows/prettier-fix.yml
+++ b/.github/workflows/prettier-fix.yml
@@ -17,5 +17,5 @@ jobs:
         # Use the latest commit in the main branch.
         uses: WorkOfStan/prettier-fix@main
         with:
-        #  node-version: "20"
+          #node-version: "20"
           commit-changes: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Security` in case of vulnerabilities
 
-## [1.1.0] - 2024-11-29
+## [1.1.0] - 2024-11-30
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Security` in case of vulnerabilities
 
+## [1.1.0] - 2024-11-29
+
+### Added
+
+- The input parameter `commit-changes: true` to commit to the current branch.
+- **Customizable Commit Message**: Introduced an input `commit-message` to allow users to specify a custom commit message.
+- **Branch Name Output**: The `branch-name` is now provided as an output for downstream workflows.
+- **Prettier Installation Check**: Ensures `Prettier` is installed and available even if `skip-package-setup` is true.
+- Added detailed logging to improve the visibility of action progress and conditional steps.
+
+### Changed
+
+- **Manual Workflow File Change Warnings**: Improved warnings for `.github/workflows/` changes, providing clear guidance without restoring or resetting these files.
+- **Cleanup Logic Enhancements**: Enhanced cleanup logic to remove temporary `package.json`, `package-lock.json`, and `node_modules` only when necessary.
+
 ## [1.0.3] - 2024-10-20
 
 ### Fixed
@@ -42,7 +57,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - This GitHub Action automates Prettier formatting across your project, ensuring consistent code styling by creating a new branch for review when necessary. It simplifies integrating Prettier into your workflow, although updates to workflow YAML files in `.github/workflows/` must be done manually.
 
-[Unreleased]: https://github.com/WorkOfStan/prettier-fix/compare/v1.0.3...HEAD
+[Unreleased]: https://github.com/WorkOfStan/prettier-fix/compare/v1.1.0...HEAD
+[1.1.0]: https://github.com/WorkOfStan/prettier-fix/compare/v1.0.3...v1.1.0?w=1
 [1.0.3]: https://github.com/WorkOfStan/prettier-fix/compare/v1.0.2...v1.0.3?w=1
 [1.0.2]: https://github.com/WorkOfStan/prettier-fix/compare/v1.0.1...v1.0.2?w=1
 [1.0.1]: https://github.com/WorkOfStan/prettier-fix/compare/v1.0.0...v1.0.1?w=1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Customizable Commit Message**: Introduced an input `commit-message` to allow users to specify a custom commit message.
 - **Branch Name Output**: The `branch-name` is now provided as an output for downstream workflows.
 - **Prettier Installation Check**: Ensures `Prettier` is installed and available even if `skip-package-setup` is true.
-- Added detailed logging to improve the visibility of action progress and conditional steps.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Customizable Commit Message**: Introduced an input `commit-message` to allow users to specify a custom commit message.
 - **Branch Name Output**: The `branch-name` is now provided as an output for downstream workflows.
 - **Prettier Installation Check**: Ensures `Prettier` is installed and available even if `skip-package-setup` is true.
+- Notice about a successful commit.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -24,18 +24,20 @@ Note: This action is not blocking, so the status remains green even if changes a
 
 ### Inputs
 
-| Input                | Description                                                                    | Default                                          |
-| -------------------- | ------------------------------------------------------------------------------ | ------------------------------------------------ |
-| `node-version`       | Node.js version to use                                                         | `"20"`                                           |
-| `commit-changes`     | If `true`, commits changes to the current branch instead of creating a new one | `false`                                          |
-| `skip-package-setup` | If `true`, skips `npm init` and dependency installation steps                  | `false`                                          |
-| `commit-message`     | Commit message for the changes                                                 | `"Prettier fixes applied automatically"`         |
+| Input                | Description                                                                    | Default                                  |
+| -------------------- | ------------------------------------------------------------------------------ | ---------------------------------------- |
+| `node-version`       | Node.js version to use                                                         | `"20"`                                   |
+| `commit-changes`     | If `true`, commits changes to the current branch instead of creating a new one | `false`                                  |
+| `skip-package-setup` | If `true`, skips `npm init` and dependency installation steps                  | `false`                                  |
+| `commit-message`     | Commit message for the changes                                                 | `"Prettier fixes applied automatically"` |
 
 Note: it would be possible to use `git-user-name` and `git-user-email` as inputs to set-up the info about the author of the commits, but for clarity [actions/checkout](https://github.com/actions/checkout?tab=readme-ov-file#push-a-commit-using-the-built-in-token) recommends
+
 ```
   git config user.name "github-actions[bot]"
   git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 ```
+
 Btw: GitHub displays name according to a known email.
 
 ### Outputs

--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ Note: This action is not blocking, so the status remains green even if changes a
 | -------------------- | ------------------------------------------------------------------------------ | ------------------------------------------------ |
 | `node-version`       | Node.js version to use                                                         | `"20"`                                           |
 | `commit-changes`     | If `true`, commits changes to the current branch instead of creating a new one | `false`                                          |
+| `git-user-name`      | Git user name for commits                                                      | `"github-actions[bot]"`                          |
+| `git-user-email`     | Git user email for commits                                                     | `"github-actions[bot]@users.noreply.github.com"` |
 | `skip-package-setup` | If `true`, skips `npm init` and dependency installation steps                  | `false`                                          |
 | `commit-message`     | Commit message for the changes                                                 | `"Prettier fixes applied automatically"`         |
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ With the release of [Super-Linter](https://github.com/super-linter/super-linter)
 ## Features
 
 - Automatically formats code using Prettier.
-- Creates a new branch (prefixed with `prettier/`) if changes are required, making it easy to review and merge.
+- Creates a new branch (prefixed with `prettier/fix`) if changes are required, making it easy to review and merge. Or you can set the input parameter `commit-changes: true` to commit to the current branch.
 - Allows for customizable commit messages via the `commit-message` input.
 - Provides the branch name as an output for downstream workflows.
 - Issues warnings for manual changes needed in `.github/workflows` files.
@@ -17,10 +17,10 @@ With the release of [Super-Linter](https://github.com/super-linter/super-linter)
 ## How to Use It
 
 To automate Prettier, simply add [the provided YAML configuration](.github/workflows/prettier-fix.yml) to your repository.
-If needed, by default, a new branch with a name starting with `prettier/` will be created, making it easy to review and merge the fixes into your main branch.
-You can however set the input parameter `commit-changes: true` to commit to the current branch.
 
-Note: This action is not blocking, so the status remains green even if changes are proposed in the form of a new branch. It’s up to you to either create a pull request to merge the changes or delete the branch.
+By default, if needed, a new branch with a name starting with `prettier/fix` will be created, making it easy to review and merge the fixes into your main branch.
+
+Note: This action is not blocking, so the status remains green even if changes are proposed in the form of a new branch. Then it’s up to you to either create a pull request to merge the changes or delete the branch.
 
 ### Inputs
 

--- a/README.md
+++ b/README.md
@@ -24,20 +24,20 @@ Note: This action is not blocking, so the status remains green even if changes a
 
 ### Inputs
 
-| Input                | Description                                                                 | Default                    |
-|----------------------|-----------------------------------------------------------------------------|----------------------------|
-| `node-version`       | Node.js version to use                                                     | `"20"`                     |
-| `commit-changes`     | If `true`, commits changes to the current branch instead of creating a new one | `false`                    |
-| `git-user-name`      | Git user name for commits                                                  | `"github-actions[bot]"`   |
-| `git-user-email`     | Git user email for commits                                                 | `"github-actions[bot]@users.noreply.github.com"` |
-| `skip-package-setup` | If `true`, skips `npm init` and dependency installation steps               | `false`                    |
-| `commit-message`     | Commit message for the changes                                             | `"Prettier fixes applied automatically"` |
+| Input                | Description                                                                    | Default                                          |
+| -------------------- | ------------------------------------------------------------------------------ | ------------------------------------------------ |
+| `node-version`       | Node.js version to use                                                         | `"20"`                                           |
+| `commit-changes`     | If `true`, commits changes to the current branch instead of creating a new one | `false`                                          |
+| `git-user-name`      | Git user name for commits                                                      | `"github-actions[bot]"`                          |
+| `git-user-email`     | Git user email for commits                                                     | `"github-actions[bot]@users.noreply.github.com"` |
+| `skip-package-setup` | If `true`, skips `npm init` and dependency installation steps                  | `false`                                          |
+| `commit-message`     | Commit message for the changes                                                 | `"Prettier fixes applied automatically"`         |
 
 ### Outputs
 
-| Output         | Description                           |
-|----------------|---------------------------------------|
-| `branch-name`  | The name of the branch created/used   |
+| Output        | Description                         |
+| ------------- | ----------------------------------- |
+| `branch-name` | The name of the branch created/used |
 
 ## Important Note for Workflow YAMLs
 

--- a/README.md
+++ b/README.md
@@ -28,10 +28,15 @@ Note: This action is not blocking, so the status remains green even if changes a
 | -------------------- | ------------------------------------------------------------------------------ | ------------------------------------------------ |
 | `node-version`       | Node.js version to use                                                         | `"20"`                                           |
 | `commit-changes`     | If `true`, commits changes to the current branch instead of creating a new one | `false`                                          |
-| `git-user-name`      | Git user name for commits                                                      | `"github-actions[bot]"`                          |
-| `git-user-email`     | Git user email for commits                                                     | `"github-actions[bot]@users.noreply.github.com"` |
 | `skip-package-setup` | If `true`, skips `npm init` and dependency installation steps                  | `false`                                          |
 | `commit-message`     | Commit message for the changes                                                 | `"Prettier fixes applied automatically"`         |
+
+Note: it would be possible to use `git-user-name` and `git-user-email` as inputs to set-up the info about the author of the commits, but for clarity [actions/checkout](https://github.com/actions/checkout?tab=readme-ov-file#push-a-commit-using-the-built-in-token) recommends
+```
+  git config user.name "github-actions[bot]"
+  git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+```
+Btw: GitHub displays name according to a known email.
 
 ### Outputs
 

--- a/README.md
+++ b/README.md
@@ -6,13 +6,40 @@ With the release of [Super-Linter](https://github.com/super-linter/super-linter)
   <img src=".github/images/social-preview.png" width="128" alt="accessibility text">
 </p>
 
-### How to Use It
+## Features
 
-To automate Prettier, simply add [the provided YAML configuration](.github/workflows/prettier-fix.yml) to your repository. If needed, a new branch with a name starting with `prettier/` will be created, making it easy to review and merge the fixes into your main branch.
+- Automatically formats code using Prettier.
+- Creates a new branch (prefixed with `prettier/`) if changes are required, making it easy to review and merge.
+- Allows for customizable commit messages via the `commit-message` input.
+- Provides the branch name as an output for downstream workflows.
+- Issues warnings for manual changes needed in `.github/workflows` files.
+
+## How to Use It
+
+To automate Prettier, simply add [the provided YAML configuration](.github/workflows/prettier-fix.yml) to your repository.
+If needed, by default, a new branch with a name starting with `prettier/` will be created, making it easy to review and merge the fixes into your main branch.
+You can however set the input parameter `commit-changes: true` to commit to the current branch.
 
 Note: This action is not blocking, so the status remains green even if changes are proposed in the form of a new branch. It’s up to you to either create a pull request to merge the changes or delete the branch.
 
-### Important Note for Workflow YAMLs
+### Inputs
+
+| Input                | Description                                                                 | Default                    |
+|----------------------|-----------------------------------------------------------------------------|----------------------------|
+| `node-version`       | Node.js version to use                                                     | `"20"`                     |
+| `commit-changes`     | If `true`, commits changes to the current branch instead of creating a new one | `false`                    |
+| `git-user-name`      | Git user name for commits                                                  | `"github-actions[bot]"`   |
+| `git-user-email`     | Git user email for commits                                                 | `"github-actions[bot]@users.noreply.github.com"` |
+| `skip-package-setup` | If `true`, skips `npm init` and dependency installation steps               | `false`                    |
+| `commit-message`     | Commit message for the changes                                             | `"Prettier fixes applied automatically"` |
+
+### Outputs
+
+| Output         | Description                           |
+|----------------|---------------------------------------|
+| `branch-name`  | The name of the branch created/used   |
+
+## Important Note for Workflow YAMLs
 
 If the changes involve files within the `.github/workflows/` directory, these cannot be done automatically and need to be updated manually.
 So, it also checks for any changes made to the `.github/workflows` directory and issues a warning if changes are detected, advising you to manually review and fix these to avoid conflicts with Super-Linter.

--- a/README.md
+++ b/README.md
@@ -28,8 +28,6 @@ Note: This action is not blocking, so the status remains green even if changes a
 | -------------------- | ------------------------------------------------------------------------------ | ------------------------------------------------ |
 | `node-version`       | Node.js version to use                                                         | `"20"`                                           |
 | `commit-changes`     | If `true`, commits changes to the current branch instead of creating a new one | `false`                                          |
-| `git-user-name`      | Git user name for commits                                                      | `"github-actions[bot]"`                          |
-| `git-user-email`     | Git user email for commits                                                     | `"github-actions[bot]@users.noreply.github.com"` |
 | `skip-package-setup` | If `true`, skips `npm init` and dependency installation steps                  | `false`                                          |
 | `commit-message`     | Commit message for the changes                                                 | `"Prettier fixes applied automatically"`         |
 

--- a/action.yml
+++ b/action.yml
@@ -103,11 +103,13 @@ runs:
         # Determine branch name based on commit-changes input
         if ${{ inputs.commit-changes }}; then
           BRANCH_NAME=$(git branch --show-current)
+          NOTICE_MESSAGE="A commit was successfully added to the current branch: $BRANCH_NAME"
         else
           # name includes timestam and short_hash
           BRANCH_NAME="prettier/fix-$(date +'%y%m%d%H%M%S')-$(git rev-parse --short HEAD)"
           git checkout -b "$BRANCH_NAME"
           echo "::warning title=New branch created::Consider pull request for a new branch: $BRANCH_NAME (or delete it)"
+          NOTICE_MESSAGE="A commit was successfully added to the new branch: $BRANCH_NAME"
         fi
 
         # Configure Git user
@@ -117,7 +119,7 @@ runs:
         # Commit and push changes with custom message
         git commit -m "${{ inputs.commit-message }} on $(date +'%Y-%m-%d %H:%M:%S')"
         git push origin "$BRANCH_NAME"
-        echo "::notice title=Commit added::A commit was successfully added to the branch: $BRANCH_NAME"
+        echo "::notice title=Commit added::$NOTICE_MESSAGE"
 
         # Set branch name as output
         echo "branch-name=$BRANCH_NAME" >> $GITHUB_OUTPUT

--- a/action.yml
+++ b/action.yml
@@ -55,14 +55,6 @@ runs:
     - name: Handle package.json, Install dependencies, Run Prettier, and Clean up
       run: |
         CREATED_PACKAGE_JSON=false
-        #debug
-        if [ ! -f package.json ]; then
-          echo "package.json NENI"
-        fi
-        if [ -f package.json ]; then
-          echo "package.json JE"
-        fi
-        #/debug
         if [ "${{ inputs.skip-package-setup }}" != "true" ]; then
           if [ ! -f package.json ]; then
             echo "Setting up package.json..."
@@ -72,15 +64,6 @@ runs:
           echo "... and installing dependencies..."
           npm install
         fi
-        #debug
-        if [ ! -f package.json ]; then
-          echo "package.json NENI"
-        fi
-        if [ -f package.json ]; then
-          echo "package.json JE"
-        fi
-        echo "$CREATED_PACKAGE_JSON in IDIN"
-        #/debug
 
         if ! npx prettier -v > /dev/null 2>&1; then
           echo "Prettier not found. Installing temporarily..."
@@ -90,20 +73,11 @@ runs:
         echo "Running Prettier..."
         npx prettier --write .
 
-        echo "$CREATED_PACKAGE_JSON in CTF"
         if [ "$CREATED_PACKAGE_JSON" == "true" ]; then
           echo "Cleaning up temporary files..."
           rm -f package.json package-lock.json
           rm -rf node_modules
         fi
-        #debug
-        if [ ! -f package.json ]; then
-          echo "package.json NENI"
-        fi
-        if [ -f package.json ]; then
-          echo "package.json JE"
-        fi
-        #/debug
         # Keep in the same step to hold the context for $CREATED_PACKAGE_JSON
       shell: bash
 

--- a/action.yml
+++ b/action.yml
@@ -79,6 +79,7 @@ runs:
         if [ -f package.json ]; then
           echo "package.json JE"
         fi
+        echo "$CREATED_PACKAGE_JSON in IDIN"
         #/debug
       shell: bash
 
@@ -98,6 +99,7 @@ runs:
 
     - name: Cleanup Temporary Files
       run: |
+        echo "$CREATED_PACKAGE_JSON in CTF"
         if [ "$CREATED_PACKAGE_JSON" == "true" ]; then
           echo "Cleaning up temporary files..."
           rm -f package.json package-lock.json

--- a/action.yml
+++ b/action.yml
@@ -14,8 +14,32 @@ branding:
 inputs:
   node-version:
     description: "Node.js version to use"
-    required: true
+    type: string
     default: "20"
+  commit-changes:
+    description: "If true, commit changes to the current branch"
+    type: boolean
+    default: false
+  git-user-name:
+    description: "Git user name for commits"
+    type: string
+    default: "github-actions[bot]"
+  git-user-email:
+    description: "Git user email for commits"
+    type: string
+    default: "github-actions[bot]@users.noreply.github.com"
+  skip-package-setup:
+    description: "If true, skip npm initialization and installation"
+    type: boolean
+    default: false
+  commit-message:
+    description: "Commit message for the changes"
+    type: string
+    default: "Prettier fixes applied automatically"
+
+outputs:
+  branch-name:
+    description: "The branch where changes were committed"
 
 runs:
   using: "composite"
@@ -28,29 +52,42 @@ runs:
       with:
         node-version: ${{ inputs.node-version }}
 
-    - name: Handle package.json, Install dependencies, Run Prettier, and Clean up
+    - name: Install dependencies if needed
       run: |
-        CREATED_PACKAGE_JSON=false
-        if [ ! -f package.json ]; then
-          npm init -y
-          echo "package.json created"
-          CREATED_PACKAGE_JSON=true
-        fi
-
-        # Install dependencies
-        npm install
-
-        # Run Prettier and fix
-        npx prettier --write .
-
-        # Remove package.json if it was created in this run
-        if [ "$CREATED_PACKAGE_JSON" = "true" ]; then
-          rm -f package.json package-lock.json
-          echo "package.json and package-lock.json removed"
+        if [ "${{ inputs.skip-package-setup }}" != "true" ]; then
+          echo "Setting up package.json and installing dependencies..."
+          if [ ! -f package.json ]; then
+            npm init -y
+            CREATED_PACKAGE_JSON=true
+          fi
+          npm install
         fi
       shell: bash
 
-    - name: Check if there are changes to commit
+    - name: Check and Install Prettier if Missing
+      run: |
+        if ! npx prettier -v > /dev/null 2>&1; then
+          echo "Prettier not found. Installing temporarily..."
+          npm install prettier
+        fi
+      shell: bash
+
+    - name: Run Prettier
+      run: |
+        echo "Running Prettier..."
+        npx prettier --write .
+      shell: bash
+
+    - name: Cleanup Temporary Files
+      run: |
+        if [ "${{ inputs.skip-package-setup }}" == "true" ] && [ "$CREATED_PACKAGE_JSON" == "true" ]; then
+          echo "Cleaning up temporary files..."
+          rm -f package.json package-lock.json
+          rm -rf node_modules
+        fi
+      shell: bash
+
+    - name: Commit and Push Changes if Any
       run: |
         if [ -z "$(git status --porcelain)" ]; then
           echo "No changes detected by Prettier. Exiting gracefully."
@@ -58,40 +95,43 @@ runs:
           # The rest of the script must be within the same step to really stop the execution
         fi
 
-        # Add changes
-        git add .
+        # Stage only non-workflow files
+        git add $(git diff --name-only | grep -vE '^.github/workflows/')
 
-        # Check for diffs in .github/workflows/*.yml file - to be fixed manually
+        # Check for changes in workflow files (unstaged changes) - to be fixed manually
         for file in .github/workflows/*.yml; do
-          if git diff --staged "$file" | grep -q .; then
+          if git diff "$file" | grep -q .; then
             echo "::warning title=Manual change required::Changes detected in $file. Manual intervention required to avoid conflicts with Super-Linter."
-            git diff --staged "$file"
-            # Unstage the changes git restore --staged "$file" or:
-            git reset "$file"
-            # Discard changes in the working directory, so that it doesn't trigger status --porcelain
-            git restore "$file"             
+            git diff "$file"
+            # As the workflow files are not staged, their changes do not trigger status --porcelain, so there's no need to (reset neither) restore them
           fi
         done
 
-        # Re-check after uneditable files reset
+        # Re-check after exclusions
         if [ -z "$(git status --porcelain)" ]; then
           echo "No editable changes detected by Prettier. Exiting gracefully."
           exit 0
-          # The rest of the script must be within the same step to really stop the execution
+          # The rest of the script must still be within the same step to really stop the execution
         fi
 
-        # Set branch name and create branch
-        TIMESTAMP=$(date +'%y%m%d%H%M%S')
-        SHORT_HASH=$(git rev-parse --short HEAD)
-        BRANCH_NAME="prettier/fix-${TIMESTAMP}-${SHORT_HASH}"
-        git checkout -b $BRANCH_NAME
-        echo "::warning title=New branch created::Consider pull request for a new branch: $BRANCH_NAME (or delete it)"
-        git config user.name "github-actions[bot]"
-        git config user.email "github-actions[bot]@users.noreply.github.com"
+        # Configure Git user
+        git config user.name "${{ inputs.git-user-name }}"
+        git config user.email "${{ inputs.git-user-email }}"
 
-        # Commit changes without including .github/workflows/*.yml that were reset above
-        git commit -m "Prettier fixes applied automatically on $(date +"%Y-%m-%d %H:%M:%S")"
+        # Determine branch name based on commit-changes input
+        if ${{ inputs.commit-changes }}; then
+          BRANCH_NAME=$(git branch --show-current)
+        else
+          # name includes timestam and short_hash
+          BRANCH_NAME="prettier/fix-$(date +'%y%m%d%H%M%S')-$(git rev-parse --short HEAD)"
+          git checkout -b "$BRANCH_NAME"
+          echo "::warning title=New branch created::Consider pull request for a new branch: $BRANCH_NAME (or delete it)"
+        fi
 
-        # Push changes to new branch
-        git push origin $BRANCH_NAME
+        # Commit and push changes with custom message
+        git commit -m "${{ inputs.commit-message }} on $(date +'%Y-%m-%d %H:%M:%S')"
+        git push origin "$BRANCH_NAME"
+
+        # Set branch name as output
+        echo "branch-name=$BRANCH_NAME" >> $GITHUB_OUTPUT
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -87,6 +87,13 @@ runs:
           rm -f package.json package-lock.json
           rm -rf node_modules
         fi
+        #debug
+        if [ ! -f package.json ]; then
+          echo "package.json NENI"
+        fi
+        if [ -f package.json ]; then
+          echo "package.json JE"
+        fi
       shell: bash
 
     - name: Commit and Push Changes if Any

--- a/action.yml
+++ b/action.yml
@@ -20,14 +20,6 @@ inputs:
     description: "If true, commit changes to the current branch"
     type: boolean
     default: false
-  git-user-name:
-    description: "Git user name for commits"
-    type: string
-    default: "github-actions[bot]"
-  git-user-email:
-    description: "Git user email for commits"
-    type: string
-    default: "github-actions[bot]@users.noreply.github.com"
   skip-package-setup:
     description: "If true, skip npm initialization and installation"
     type: boolean
@@ -107,13 +99,6 @@ runs:
           exit 0
           # The rest of the script must still be within the same step to really stop the execution
         fi
-
-        # Configure Git user
-        git config --local user.name "${{ inputs.git-user-name }}"
-        git config --local user.email "${{ inputs.git-user-email }}"
-        # Debugging: Verify the configuration
-        echo "Git user name: $(git config --get user.name)"
-        echo "Git user email: $(git config --get user.email)"
 
         # Determine branch name based on commit-changes input
         if ${{ inputs.commit-changes }}; then

--- a/action.yml
+++ b/action.yml
@@ -54,12 +54,14 @@ runs:
 
     - name: Install dependencies if needed
       run: |
+        CREATED_PACKAGE_JSON=false
         if [ "${{ inputs.skip-package-setup }}" != "true" ]; then
-          echo "Setting up package.json and installing dependencies..."
           if [ ! -f package.json ]; then
+            echo "Setting up package.json..."
             npm init -y
             CREATED_PACKAGE_JSON=true
           fi
+          echo "... and installing dependencies..."
           npm install
         fi
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -109,8 +109,11 @@ runs:
         fi
 
         # Configure Git user
-        git config user.name "${{ inputs.git-user-name }}"
-        git config user.email "${{ inputs.git-user-email }}"
+        git config --local user.name "${{ inputs.git-user-name }}"
+        git config --local user.email "${{ inputs.git-user-email }}"
+        # Debugging: Verify the configuration
+        echo "Git user name: $(git config --get user.name)"
+        echo "Git user email: $(git config --get user.email)"
 
         # Determine branch name based on commit-changes input
         if ${{ inputs.commit-changes }}; then

--- a/action.yml
+++ b/action.yml
@@ -20,6 +20,14 @@ inputs:
     description: "If true, commit changes to the current branch"
     type: boolean
     default: false
+  git-user-name:
+    description: "Git user name for commits"
+    type: string
+    default: "github-actions[bot]"
+  git-user-email:
+    description: "Git user email for commits"
+    type: string
+    default: "github-actions[bot]@users.noreply.github.com"
   skip-package-setup:
     description: "If true, skip npm initialization and installation"
     type: boolean
@@ -109,6 +117,10 @@ runs:
           git checkout -b "$BRANCH_NAME"
           echo "::warning title=New branch created::Consider pull request for a new branch: $BRANCH_NAME (or delete it)"
         fi
+
+        # Configure Git user
+        git config user.name "${{ inputs.git-user-name }}"
+        git config user.email "${{ inputs.git-user-email }}"
 
         # Commit and push changes with custom message
         git commit -m "${{ inputs.commit-message }} on $(date +'%Y-%m-%d %H:%M:%S')"

--- a/action.yml
+++ b/action.yml
@@ -117,6 +117,7 @@ runs:
         # Commit and push changes with custom message
         git commit -m "${{ inputs.commit-message }} on $(date +'%Y-%m-%d %H:%M:%S')"
         git push origin "$BRANCH_NAME"
+        echo "::notice title=Commit added::A commit was successfully added to the branch: $BRANCH_NAME"
 
         # Set branch name as output
         echo "branch-name=$BRANCH_NAME" >> $GITHUB_OUTPUT

--- a/action.yml
+++ b/action.yml
@@ -80,7 +80,7 @@ runs:
 
     - name: Cleanup Temporary Files
       run: |
-        if [ "${{ inputs.skip-package-setup }}" == "true" ] && [ "$CREATED_PACKAGE_JSON" == "true" ]; then
+        if [ "$CREATED_PACKAGE_JSON" == "true" ]; then
           echo "Cleaning up temporary files..."
           rm -f package.json package-lock.json
           rm -rf node_modules

--- a/action.yml
+++ b/action.yml
@@ -55,6 +55,14 @@ runs:
     - name: Install dependencies if needed
       run: |
         CREATED_PACKAGE_JSON=false
+        #debug
+        if [ ! -f package.json ]; then
+          echo "package.json NENI"
+        fi
+        if [ -f package.json ]; then
+          echo "package.json JE"
+        fi
+        #/debug
         if [ "${{ inputs.skip-package-setup }}" != "true" ]; then
           if [ ! -f package.json ]; then
             echo "Setting up package.json..."
@@ -64,6 +72,14 @@ runs:
           echo "... and installing dependencies..."
           npm install
         fi
+        #debug
+        if [ ! -f package.json ]; then
+          echo "package.json NENI"
+        fi
+        if [ -f package.json ]; then
+          echo "package.json JE"
+        fi
+        #/debug
       shell: bash
 
     - name: Check and Install Prettier if Missing
@@ -94,6 +110,7 @@ runs:
         if [ -f package.json ]; then
           echo "package.json JE"
         fi
+        #/debug
       shell: bash
 
     - name: Commit and Push Changes if Any

--- a/action.yml
+++ b/action.yml
@@ -20,14 +20,6 @@ inputs:
     description: "If true, commit changes to the current branch"
     type: boolean
     default: false
-  git-user-name:
-    description: "Git user name for commits"
-    type: string
-    default: "github-actions[bot]"
-  git-user-email:
-    description: "Git user email for commits"
-    type: string
-    default: "github-actions[bot]@users.noreply.github.com"
   skip-package-setup:
     description: "If true, skip npm initialization and installation"
     type: boolean
@@ -119,8 +111,8 @@ runs:
         fi
 
         # Configure Git user
-        git config user.name "${{ inputs.git-user-name }}"
-        git config user.email "${{ inputs.git-user-email }}"
+        git config user.name "github-actions[bot]"
+        git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
         # Commit and push changes with custom message
         git commit -m "${{ inputs.commit-message }} on $(date +'%Y-%m-%d %H:%M:%S')"

--- a/action.yml
+++ b/action.yml
@@ -52,7 +52,7 @@ runs:
       with:
         node-version: ${{ inputs.node-version }}
 
-    - name: Install dependencies if needed
+    - name: Handle package.json, Install dependencies, Run Prettier, and Clean up
       run: |
         CREATED_PACKAGE_JSON=false
         #debug
@@ -81,24 +81,15 @@ runs:
         fi
         echo "$CREATED_PACKAGE_JSON in IDIN"
         #/debug
-      shell: bash
 
-    - name: Check and Install Prettier if Missing
-      run: |
         if ! npx prettier -v > /dev/null 2>&1; then
           echo "Prettier not found. Installing temporarily..."
           npm install prettier
         fi
-      shell: bash
 
-    - name: Run Prettier
-      run: |
         echo "Running Prettier..."
         npx prettier --write .
-      shell: bash
 
-    - name: Cleanup Temporary Files
-      run: |
         echo "$CREATED_PACKAGE_JSON in CTF"
         if [ "$CREATED_PACKAGE_JSON" == "true" ]; then
           echo "Cleaning up temporary files..."
@@ -113,6 +104,7 @@ runs:
           echo "package.json JE"
         fi
         #/debug
+        # Keep in the same step to hold the context for $CREATED_PACKAGE_JSON
       shell: bash
 
     - name: Commit and Push Changes if Any

--- a/action.yml
+++ b/action.yml
@@ -117,7 +117,7 @@ runs:
         git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
         # Commit and push changes with custom message
-        git commit -m "${{ inputs.commit-message }} on $(date +'%Y-%m-%d %H:%M:%S')"
+        git commit -m "${{ inputs.commit-message }} on $(date +'%Y-%m-%d %H:%M:%S') UTC"
         git push origin "$BRANCH_NAME"
         echo "::notice title=Commit added::$NOTICE_MESSAGE"
 


### PR DESCRIPTION
### Added

- The input parameter `commit-changes: true` to commit to the current branch.
- **Customizable Commit Message**: Introduced an input `commit-message` to allow users to specify a custom commit message.
- **Branch Name Output**: The `branch-name` is now provided as an output for downstream workflows.
- **Prettier Installation Check**: Ensures `Prettier` is installed and available even if `skip-package-setup` is true.
- Added detailed logging to improve the visibility of action progress and conditional steps.

### Changed

- **Manual Workflow File Change Warnings**: Improved warnings for `.github/workflows/` changes, providing clear guidance without restoring or resetting these files.
- **Cleanup Logic Enhancements**: Enhanced cleanup logic to remove temporary `package.json`, `package-lock.json`, and `node_modules` only when necessary.