### PR TITLE
fix: only warn about `.github/workflows/*.yml` issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Security` in case of vulnerabilities
 
+## [1.1.5] - 2025-06-21
+
+fix: only warn about `.github/workflows/*.yml` issues
+
+### Fixed
+
+- if only a `.github/workflows/*.yml` needs prettier fix, then end with warning, not with an error
+
 ## [1.1.4] - 2025-05-31
 
 chore: outputs `changed-files`
@@ -98,7 +106,8 @@ Fix pull request issues
 
 - This GitHub Action automates Prettier formatting across your project, ensuring consistent code styling by creating a new branch for review when necessary. It simplifies integrating Prettier into your workflow, although updates to workflow YAML files in `.github/workflows/` must be done manually.
 
-[Unreleased]: https://github.com/WorkOfStan/prettier-fix/compare/v1.1.4...HEAD
+[Unreleased]: https://github.com/WorkOfStan/prettier-fix/compare/v1.1.5...HEAD
+[1.1.5]: https://github.com/WorkOfStan/prettier-fix/compare/v1.1.4...v1.1.5?w=1
 [1.1.4]: https://github.com/WorkOfStan/prettier-fix/compare/v1.1.3...v1.1.4?w=1
 [1.1.3]: https://github.com/WorkOfStan/prettier-fix/compare/v1.1.2...v1.1.3?w=1
 [1.1.2]: https://github.com/WorkOfStan/prettier-fix/compare/v1.1.1...v1.1.2?w=1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ fix: only warn about `.github/workflows/*.yml` issues
 
 ### Fixed
 
-- if only a `.github/workflows/*.yml` needs prettier fix, then end with warning, not with an error
+- if only `.github/workflows/*.yml` need prettier fix, then end with warning, not with an error
 
 ## [1.1.4] - 2025-05-31
 

--- a/action.yml
+++ b/action.yml
@@ -84,7 +84,7 @@ runs:
         echo "Running Prettier..."
         npx prettier -v
         if [ -n "${{ inputs.prettier-config-path }}" ]; then
-          npx prettier --config "${{ inputs.prettier-config-path }}" --write . --log-level debug
+          npx prettier --config "${{ inputs.prettier-config-path }}" --write .
         else
           npx prettier --write .
         fi

--- a/action.yml
+++ b/action.yml
@@ -150,9 +150,10 @@ runs:
 
         # Only add changed non-workflow files, safe for spaces
         echo "DEBUG: Only add changed non-workflow files"
-        git status --porcelain | awk '{print $2}' | grep -vE '^.github/workflows/' | while IFS= read -r file; do git add "$file"; done
+        git status --porcelain | awk '{print $2}' | grep -vE '^.github/workflows/' | while IFS= read -r file; do echo "DEBUG git add $file";git add "$file"; done
 
         # Check for changes in workflow files (unstaged changes) - to be fixed manually
+        echo "DEBUG Check for changes in workflow files"
         for file in .github/workflows/*.yml; do
           echo "DEBUG: to be git diff $file"
           if git diff "$file" | grep -q .; then

--- a/action.yml
+++ b/action.yml
@@ -155,8 +155,13 @@ runs:
         git status --porcelain | awk '{print $2}'
         echo "grep"
         git status --porcelain | awk '{print $2}' | grep -vE '^.github/workflows/'
-        echo "while"
-        git status --porcelain | awk '{print $2}' | grep -vE '^.github/workflows/' | while IFS= read -r file; do echo "DEBUG git add $file";git add "$file"; done
+        #echo "while"
+        #git status --porcelain | awk '{print $2}' | grep -vE '^.github/workflows/' | while IFS= read -r file; do echo "DEBUG git add $file";git add "$file"; done
+        echo "DEBUG new"
+        git status --porcelain | cut -c4- | grep -vE '^.github/workflows/' | while IFS= read -r file; do
+          echo "DEBUG git add $file"
+          git add "$file"
+        done
 
         # Check for changes in workflow files (unstaged changes) - to be fixed manually
         echo "DEBUG Check for changes in workflow files"

--- a/action.yml
+++ b/action.yml
@@ -160,10 +160,15 @@ runs:
         echo "DEBUG grep2"
         git status --porcelain | cut -c4- | grep -vE '^.github/workflows/'
         echo "DEBUG new"
-        git status --porcelain | cut -c4- | grep -vE '^.github/workflows/' | while IFS= read -r file; do
-          echo "DEBUG git add $file"
-          git add "$file"
-        done
+        if output=$(git status --porcelain | cut -c4- | grep -vE '^.github/workflows/'); then
+          printf '%s\n' "$output" | while IFS= read -r file; do
+            echo "DEBUG git add $file"
+            git add "$file"
+          done
+        else
+          # no lines selected, but not a “real” error
+          echo "nothing to git add"
+        fi
 
         # Check for changes in workflow files (unstaged changes) - to be fixed manually
         echo "DEBUG Check for changes in workflow files"

--- a/action.yml
+++ b/action.yml
@@ -149,10 +149,12 @@ runs:
         fi
 
         # Only add changed non-workflow files, safe for spaces
+        echo "DEBUG: Only add changed non-workflow files"
         git status --porcelain | awk '{print $2}' | grep -vE '^.github/workflows/' | while IFS= read -r file; do git add "$file"; done
 
         # Check for changes in workflow files (unstaged changes) - to be fixed manually
         for file in .github/workflows/*.yml; do
+          echo "DEBUG: to be git diff $file"
           if git diff "$file" | grep -q .; then
             echo "::warning title=Manual change required::Changes detected in $file. Manual intervention required to avoid conflicts with Super-Linter."
             git diff "$file"
@@ -177,10 +179,12 @@ runs:
         fi
 
         # Configure Git user
+        echo "DEBUG: config git user"
         git config user.name "github-actions[bot]"
         git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
         # Commit and push changes with custom message
+        echo "DEBUG: git commit"
         git commit -m "${{ inputs.commit-message }} on $(date +'%Y-%m-%d %H:%M:%S') UTC"
 
         echo "::notice title=Prettier commit adding::${{ env.NOTICE_MESSAGE }}"

--- a/action.yml
+++ b/action.yml
@@ -86,7 +86,7 @@ runs:
         if [ -n "${{ inputs.prettier-config-path }}" ]; then
           npx prettier --config "${{ inputs.prettier-config-path }}" --write . --log-level debug
         else
-          npx prettier --write . --log-level debug
+          npx prettier --write .
         fi
 
         if [ "$CREATED_PACKAGE_JSON" == "true" ]; then
@@ -149,9 +149,7 @@ runs:
         fi
 
         # Check for changes in workflow files (unstaged changes) - to be fixed manually
-        echo "DEBUG Check for changes in workflow files"
         for file in .github/workflows/*.yml; do
-          echo "DEBUG: to be git diff $file"
           if git diff "$file" | grep -q .; then
             echo "::warning title=Manual change required::Changes detected in $file. Manual intervention required to avoid conflicts with Super-Linter."
             git diff "$file"
@@ -160,35 +158,19 @@ runs:
         done
 
         # Only add changed non-workflow files, safe for spaces
-        echo "DEBUG: Only add changed non-workflow files"
-        git status --porcelain
-        echo "awk"
-        git status --porcelain | awk '{print $2}'
-        #echo "grep"
-        #git status --porcelain | awk '{print $2}' | grep -vE '^.github/workflows/'
-        #echo "while"
-        #git status --porcelain | awk '{print $2}' | grep -vE '^.github/workflows/' | while IFS= read -r file; do echo "DEBUG git add $file";git add "$file"; done
-        #echo "DEBUG grep2"
-        #git status --porcelain | cut -c4- | grep -vE '^.github/workflows/'
-        echo "DEBUG new"
+        # Why cut at -c4-? Because the first 3 characters in git status --porcelain are status indicators (like staged/unstaged/ignored), and you just want the actual file path that follows.
         if output=$(git status --porcelain | cut -c4- | grep -vE '^.github/workflows/'); then
           printf '%s\n' "$output" | while IFS= read -r file; do
-            echo "DEBUG git add $file"
             git add "$file"
           done
         else
-          # no lines selected, but not a “real” error
-          #echo "nothing to git add"
-            echo "No editable changes detected by Prettier. Exiting gracefully."
+          # no lines selected, but not a “real” error (as grep resulting in no lines ends with exit 1)
+          echo "No editable changes detected by Prettier. Exiting gracefully."
           echo "branch-name=" >> $GITHUB_OUTPUT
           echo "changed-files=" >> $GITHUB_OUTPUT
           exit 0
           # The rest of the script must still be within the same step to really stop the execution
         fi
-
-        # Re-check after exclusions
-        #if [ -z "$(git status --porcelain)" ]; then
-        #fi
 
         if [ -z "${{ env.BRANCH_NAME }}" ]; then
           echo "::error title=Detached HEAD::No valid branch found, skipping commit."
@@ -198,12 +180,10 @@ runs:
         fi
 
         # Configure Git user
-        echo "DEBUG: config git user"
         git config user.name "github-actions[bot]"
         git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
         # Commit and push changes with custom message
-        echo "DEBUG: git commit"
         git commit -m "${{ inputs.commit-message }} on $(date +'%Y-%m-%d %H:%M:%S') UTC"
 
         echo "::notice title=Prettier commit adding::${{ env.NOTICE_MESSAGE }}"

--- a/action.yml
+++ b/action.yml
@@ -153,12 +153,12 @@ runs:
         git status --porcelain
         echo "awk"
         git status --porcelain | awk '{print $2}'
-        echo "grep"
-        git status --porcelain | awk '{print $2}' | grep -vE '^.github/workflows/'
+        #echo "grep"
+        #git status --porcelain | awk '{print $2}' | grep -vE '^.github/workflows/'
         #echo "while"
         #git status --porcelain | awk '{print $2}' | grep -vE '^.github/workflows/' | while IFS= read -r file; do echo "DEBUG git add $file";git add "$file"; done
-        echo "DEBUG grep2"
-        git status --porcelain | cut -c4- | grep -vE '^.github/workflows/'
+        #echo "DEBUG grep2"
+        #git status --porcelain | cut -c4- | grep -vE '^.github/workflows/'
         echo "DEBUG new"
         if output=$(git status --porcelain | cut -c4- | grep -vE '^.github/workflows/'); then
           printf '%s\n' "$output" | while IFS= read -r file; do

--- a/action.yml
+++ b/action.yml
@@ -150,6 +150,9 @@ runs:
 
         # Only add changed non-workflow files, safe for spaces
         echo "DEBUG: Only add changed non-workflow files"
+        git status --porcelain
+        git status --porcelain | awk '{print $2}'
+        git status --porcelain | awk '{print $2}' | grep -vE '^.github/workflows/'
         git status --porcelain | awk '{print $2}' | grep -vE '^.github/workflows/' | while IFS= read -r file; do echo "DEBUG git add $file";git add "$file"; done
 
         # Check for changes in workflow files (unstaged changes) - to be fixed manually

--- a/action.yml
+++ b/action.yml
@@ -151,8 +151,11 @@ runs:
         # Only add changed non-workflow files, safe for spaces
         echo "DEBUG: Only add changed non-workflow files"
         git status --porcelain
+        echo "awk"
         git status --porcelain | awk '{print $2}'
+        echo "grep"
         git status --porcelain | awk '{print $2}' | grep -vE '^.github/workflows/'
+        echo "while"
         git status --porcelain | awk '{print $2}' | grep -vE '^.github/workflows/' | while IFS= read -r file; do echo "DEBUG git add $file";git add "$file"; done
 
         # Check for changes in workflow files (unstaged changes) - to be fixed manually

--- a/action.yml
+++ b/action.yml
@@ -84,9 +84,9 @@ runs:
         echo "Running Prettier..."
         npx prettier -v
         if [ -n "${{ inputs.prettier-config-path }}" ]; then
-          npx prettier --config "${{ inputs.prettier-config-path }}" --write .
+          npx prettier --config "${{ inputs.prettier-config-path }}" --write . --log-level debug
         else
-          npx prettier --write .
+          npx prettier --write . --log-level debug
         fi
 
         if [ "$CREATED_PACKAGE_JSON" == "true" ]; then

--- a/action.yml
+++ b/action.yml
@@ -157,6 +157,8 @@ runs:
         git status --porcelain | awk '{print $2}' | grep -vE '^.github/workflows/'
         #echo "while"
         #git status --porcelain | awk '{print $2}' | grep -vE '^.github/workflows/' | while IFS= read -r file; do echo "DEBUG git add $file";git add "$file"; done
+        echo "DEBUG grep2"
+        git status --porcelain | cut -c4- | grep -vE '^.github/workflows/'
         echo "DEBUG new"
         git status --porcelain | cut -c4- | grep -vE '^.github/workflows/' | while IFS= read -r file; do
           echo "DEBUG git add $file"

--- a/action.yml
+++ b/action.yml
@@ -148,6 +148,17 @@ runs:
           # The rest of the script must be within the same step to really stop the execution
         fi
 
+        # Check for changes in workflow files (unstaged changes) - to be fixed manually
+        echo "DEBUG Check for changes in workflow files"
+        for file in .github/workflows/*.yml; do
+          echo "DEBUG: to be git diff $file"
+          if git diff "$file" | grep -q .; then
+            echo "::warning title=Manual change required::Changes detected in $file. Manual intervention required to avoid conflicts with Super-Linter."
+            git diff "$file"
+            # As the workflow files are not staged, their changes do not trigger status --porcelain, so there's no need to (reset neither) restore them
+          fi
+        done
+
         # Only add changed non-workflow files, safe for spaces
         echo "DEBUG: Only add changed non-workflow files"
         git status --porcelain
@@ -167,28 +178,17 @@ runs:
           done
         else
           # no lines selected, but not a “real” error
-          echo "nothing to git add"
-        fi
-
-        # Check for changes in workflow files (unstaged changes) - to be fixed manually
-        echo "DEBUG Check for changes in workflow files"
-        for file in .github/workflows/*.yml; do
-          echo "DEBUG: to be git diff $file"
-          if git diff "$file" | grep -q .; then
-            echo "::warning title=Manual change required::Changes detected in $file. Manual intervention required to avoid conflicts with Super-Linter."
-            git diff "$file"
-            # As the workflow files are not staged, their changes do not trigger status --porcelain, so there's no need to (reset neither) restore them
-          fi
-        done
-
-        # Re-check after exclusions
-        if [ -z "$(git status --porcelain)" ]; then
-          echo "No editable changes detected by Prettier. Exiting gracefully."
+          #echo "nothing to git add"
+            echo "No editable changes detected by Prettier. Exiting gracefully."
           echo "branch-name=" >> $GITHUB_OUTPUT
           echo "changed-files=" >> $GITHUB_OUTPUT
           exit 0
           # The rest of the script must still be within the same step to really stop the execution
         fi
+
+        # Re-check after exclusions
+        #if [ -z "$(git status --porcelain)" ]; then
+        #fi
 
         if [ -z "${{ env.BRANCH_NAME }}" ]; then
           echo "::error title=Detached HEAD::No valid branch found, skipping commit."


### PR DESCRIPTION
### Fixed

- if only `.github/workflows/*.yml` need prettier fix, then end with warning, not with an error